### PR TITLE
E2E testing added/port changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,13 +9,13 @@ app.use(express.static('./client/dist/'));
 
 
 // all environments
-app.set('port', process.env.PORT || 8080);
+app.set('port', process.env.PORT || 3000);
 app.use(bodyParser.json());       // to support JSON-encoded bodies
 app.use(bodyParser.urlencoded({     // to support URL-encoded bodies
   extended: false
 }));
 
 // start the server
-app.listen(8080, () => {
+app.listen(3000, () => {
   console.log('Server is running on http://localhost:3000 or http://127.0.0.1:3000');
 });

--- a/index.js
+++ b/index.js
@@ -9,13 +9,13 @@ app.use(express.static('./client/dist/'));
 
 
 // all environments
-app.set('port', process.env.PORT || 3000);
+app.set('port', process.env.PORT || 8080);
 app.use(bodyParser.json());       // to support JSON-encoded bodies
 app.use(bodyParser.urlencoded({     // to support URL-encoded bodies
   extended: false
 }));
 
 // start the server
-app.listen(3000, () => {
-  console.log('Server is running on http://localhost:3000 or http://127.0.0.1:3000');
+app.listen(8080, () => {
+  console.log('Server is running on http://localhost:8080 or http://127.0.0.1:8080');
 });

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "esdoc": "^0.5.2",
     "jshint": "^2.9.4",
     "mocha": "^3.2.0",
+    "nightwatch": "^0.9.14",
     "nodemon": "^1.11.0",
     "should": "^11.2.1",
     "webpack": "^1.14.0"


### PR DESCRIPTION
JSHint was already there
Added Nightwatch.js as our End 2 End testing framework
Changed default port 8080 to 3000 (one we were using everywhere)